### PR TITLE
Removed reference to travis as part of maintenance work

### DIFF
--- a/vendor/github.com/go-ini/ini/README.md
+++ b/vendor/github.com/go-ini/ini/README.md
@@ -1,6 +1,3 @@
-INI [![Build Status](https://travis-ci.org/go-ini/ini.svg?branch=master)](https://travis-ci.org/go-ini/ini) [![Sourcegraph](https://sourcegraph.com/github.com/go-ini/ini/-/badge.svg)](https://sourcegraph.com/github.com/go-ini/ini?badge)
-===
-
 ![](https://avatars0.githubusercontent.com/u/10216035?v=3&s=200)
 
 Package ini provides INI file read and write functionality in Go.

--- a/vendor/github.com/jmespath/go-jmespath/README.md
+++ b/vendor/github.com/jmespath/go-jmespath/README.md
@@ -1,7 +1,3 @@
 # go-jmespath - A JMESPath implementation in Go
 
-[![Build Status](https://img.shields.io/travis/jmespath/go-jmespath.svg)](https://travis-ci.org/jmespath/go-jmespath)
-
-
-
 See http://jmespath.org for more info.


### PR DESCRIPTION
What
Removed references to travis as part of maintenance work and ensured no travis.yml files exist

How to review
No travis.yml file or mention of travis should exist in this repo

Who can review
A member of ONS